### PR TITLE
Improved support for filters and directives and fixed dependency parsing for $provide.constant and $provide.value

### DIFF
--- a/lib/parsers/html-parser.js
+++ b/lib/parsers/html-parser.js
@@ -66,7 +66,7 @@ function parseContent(contents, metadata) {
 					});
 				} else {
 					// Add directive tokens
-					directiveToken.push(attr);
+					directiveToken.push(attr.replace(/^data-/i, ''));
 
                // Look for filters
                var attrValue = attributes[attr].replace(/\s+/g, " ");

--- a/lib/parsers/html-parser.js
+++ b/lib/parsers/html-parser.js
@@ -15,7 +15,7 @@ function parseContent(contents, metadata) {
 		animationToken = [],
 		filter = [];
 
-	// Get filters
+	// Get interpolation filters
 	var interpolationRegex = /\{\{\s*?(.*?)\s*?\}\}/g,
 		filterRegex = /(?:^|\()\s*\w+?\s*\|\s*(\w+?)\s*(?:\)|(?=\|)|$)/,
 		expression;
@@ -67,7 +67,16 @@ function parseContent(contents, metadata) {
 				} else {
 					// Add directive tokens
 					directiveToken.push(attr);
-				}
+
+               // Look for filters
+               var attrValue = attributes[attr].replace(/\s+/g, " ");
+               var filters = attrValue.split("|").map(function (filterExpression) {
+                  return filterExpression.trim().replace(/:.*/, "");
+               }).splice(1); // First element is empty
+
+               // Add filters
+               Array.prototype.push.apply(filter, filters);
+            }
 			});
 		}
 	});

--- a/lib/parsers/js-parser.js
+++ b/lib/parsers/js-parser.js
@@ -108,7 +108,10 @@ function handleComponentDefinition(node, metadata) {
 		break;
 	}
 
-	handleInjection(componentExpression, metadata);
+   // Arrays provided to $provide's constant and value methods are not injectables
+   // therefore they do not specify dependencies.
+   if (componentType !== 'constant' && componentType !== 'value')
+	   handleInjection(componentExpression, metadata);
 }
 
 function handleInjection(node, metadata) {


### PR DESCRIPTION
The JS parser wrongly adds elements of arrays defined through .constant or .value to the dependency list.

See commits.
